### PR TITLE
Fix `NSData.toByteArray`

### DIFF
--- a/mmkv-kotlin/src/appleMain/kotlin/com/ctrip/flight/mmkv/Binary.kt
+++ b/mmkv-kotlin/src/appleMain/kotlin/com/ctrip/flight/mmkv/Binary.kt
@@ -29,9 +29,14 @@ import platform.posix.memcpy
  * @author yaqiao
  */
 
-internal fun NSData.toByteArray(): ByteArray = ByteArray(this@toByteArray.length.toInt()).apply {
-    usePinned {
-        memcpy(it.addressOf(0), this@toByteArray.bytes, this@toByteArray.length)
+internal fun NSData.toByteArray(): ByteArray {
+    val size = length.toInt()
+    return ByteArray(size).apply {
+        if (size != 0) {
+            usePinned {
+                memcpy(it.addressOf(0), bytes, length)
+            }
+        }
     }
 }
 

--- a/mmkv-kotlin/src/appleTest/kotlin/com/ctrip/flight/mmkv/MMKVKMMTestIos.kt
+++ b/mmkv-kotlin/src/appleTest/kotlin/com/ctrip/flight/mmkv/MMKVKMMTestIos.kt
@@ -85,4 +85,12 @@ class MMKVKotlinTestIos {
         val value1 = mmkvImpl.takeObject(MMKVKotlinTest.KEY_NOT_EXIST, NSArray.`class`()!!)
         assertEquals(value1, null)
     }
+
+    @Test
+    fun emptyNsDataToByteArray() {
+        @Suppress("CAST_NEVER_SUCCEEDS")
+        val data = ("" as NSString).dataUsingEncoding(NSUTF8StringEncoding) as NSData
+        val bytes = data.toByteArray()
+        assert(bytes.isEmpty())
+    }
 }


### PR DESCRIPTION
`ArrayIndexOutOfBoundsException` occurs when converting empty `NSData` to `ByteArray`