### PR TITLE
Update version to 1.2.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,30 +58,30 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-34
+          key: avd-36
 
       - name: Create AVD and Generate Snapshot for Caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 35
+          api-level: 36
           target: google_apis
           arch: x86_64
           profile: pixel_6
-          emulator-build: 12694320
+          emulator-build: 13701740
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: echo "Generated AVD snapshot for caching."
 
-      - name: Run Android 15 Instrumented Tests
+      - name: Run Android 16 Instrumented Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 35
+          api-level: 36
           target: google_apis
           arch: x86_64
           profile: pixel_6
-          emulator-build: 12694320
+          emulator-build: 13701740
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('*.gradle.kts') }}
         
       - name: Build All
-        run: ./gradlew :mmkv-kotlin:assemble
+        run: pod repo update --verbose && ./gradlew :mmkv-kotlin:assemble
         
       - name: Run Native Tests
         run: ./gradlew :mmkv-kotlin:cleanMacosX64Test && ./gradlew :mmkv-kotlin:macosX64Test --stacktrace

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,10 +41,10 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('*.gradle.kts') }}
         
       - name: Build All
-        run: ./gradlew :mmkv-kotlin:assemble
+        run: pod repo update --verbose && ./gradlew :mmkv-kotlin:assemble
 
       - name: Gradle Cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
 
       - name: Publish to MavenCentral
         run: ./gradlew :mmkv-kotlin:publishAllPublicationsToMavenRepository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # MMKV-Kotlin Change Log
 
 - Date format: YYYY-MM-dd
+- 
+## v1.2.18/ 2025-07-06
+
+* Based on `Kotlin 2.2.0`, `MMKV 2.2.2`
+* Fixed a bug of function `initilize()`
+* All overload versions of function `initialize` could pass `null` as their parameter `rootDir`
 
 ## v1.2.17/ 2025-04-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ MMKV-Kotlin is a porting of [MMKV](https://github.com/Tencent/MMKV) to Kotlin Mu
 
 ### Installation Via Maven in Gradle
 
-Kotlin Multiplatform Common (kts):
+**Kotlin Multiplatform Common (kts):**
 
 ```kotlin
 dependencies {     
@@ -18,12 +18,12 @@ dependencies {
 
 Current version is based on `Kotlin 2.2.00` and `MMKV 2.2.2`.
 
-Kotlin Multiplatform for iOS/macOS applications:
+**Kotlin Multiplatform for iOS/macOS applications:**
 
 If your Kotlin Multiplatform project supports iOS or macOS, and it would be built to an Apple framework that will be
 consumed by an Xcode project. You need to install [MMKV](https://github.com/Tencent/MMKV) into your Xcode project, please refer [that](https://github.com/Tencent/MMKV/wiki/iOS_setup).
 
-Pure Android platform (kts):
+**Pure Android platform (kts):**
 
 ```kotlin
 dependencies {     
@@ -31,7 +31,7 @@ dependencies {
 }
 ```
 
-Kotlin/Native on macOS：
+**Kotlin/Native on macOS：**
 
 ```kotlin
 dependencies { 

--- a/README.md
+++ b/README.md
@@ -12,17 +12,22 @@ Kotlin Multiplatform Common (kts):
 
 ```kotlin
 dependencies {     
-    implementation("com.ctrip.flight.mmkv:mmkv-kotlin:1.2.17")
+    implementation("com.ctrip.flight.mmkv:mmkv-kotlin:1.2.18")
 }
 ```
 
-Current version is based on `Kotlin 2.1.20` and `MMKV 2.1.0`.
+Current version is based on `Kotlin 2.2.00` and `MMKV 2.2.2`.
+
+Kotlin Multiplatform for iOS/macOS applications:
+
+If your Kotlin Multiplatform project supports iOS or macOS, and it would be built to an Apple framework that will be
+consumed by an Xcode project. You need to install [MMKV](https://github.com/Tencent/MMKV) into your Xcode project, please refer [that](https://github.com/Tencent/MMKV/wiki/iOS_setup).
 
 Pure Android platform (kts):
 
 ```kotlin
 dependencies {     
-    implementation("com.ctrip.flight.mmkv:mmkv-kotlin-android:1.2.17")
+    implementation("com.ctrip.flight.mmkv:mmkv-kotlin-android:1.2.18")
 }
 ```
 
@@ -31,10 +36,10 @@ Kotlin/Native on macOS：
 ```kotlin
 dependencies { 
     // Intel Chip
-    implementation("com.ctrip.flight.mmkv:mmkv-kotlin-macosx64:1.2.17")
+    implementation("com.ctrip.flight.mmkv:mmkv-kotlin-macosx64:1.2.18")
     
     // Apple Silicon
-    implementation("com.ctrip.flight.mmkv:mmkv-kotlin-macosarm64:1.2.17")
+    implementation("com.ctrip.flight.mmkv:mmkv-kotlin-macosarm64:1.2.18")
 }
 ```
 Note, if your project is a Kotlin/Native executable program project of macOS, or it supplies a framework to an iOS application project directly, then you need to manually add the dependency of MMKV, and may need to add `linkerOpts` for MMKV and MMKVCore：

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,17 +10,22 @@ Kotlin Multiplatform Common (kts):
 
 ```kotlin
 dependencies { 
-    implementation("com.ctrip.flight.mmkv:mmkv-kotlin:1.2.17")
+    implementation("com.ctrip.flight.mmkv:mmkv-kotlin:1.2.18")
 }
 ```
 
-当前版本依赖于 `Kotlin 2.1.20` 以及 `MMKV 2.1.0`。
+当前版本依赖于 `Kotlin 2.2.0` 以及 `MMKV 2.2.2`。
+
+支持 iOS/macOS 的 Kotlin Multiplatform:
+
+如果你的 Kotlin Multiplatform 支持 iOS 或者 macOS，并且它会被构建为一个 Apple framework 供一个 Xcode 工程消费。那么你需要在你的 Xcode
+工程中安装 [MMKV](https://github.com/Tencent/MMKV)，请参考[这里](https://github.com/Tencent/MMKV/wiki/iOS_setup_cn)。
 
 纯 Android 平台（kts）：
 
 ```kotlin
 dependencies { 
-    implementation("com.ctrip.flight.mmkv:mmkv-kotlin-android:1.2.17")
+    implementation("com.ctrip.flight.mmkv:mmkv-kotlin-android:1.2.18")
 }
 ```
 
@@ -29,10 +34,10 @@ Kotlin/Native on macOS：
 ```kotlin
 dependencies { 
     // Intel 芯片
-    implementation("com.ctrip.flight.mmkv:mmkv-kotlin-macosx64:1.2.17")
+    implementation("com.ctrip.flight.mmkv:mmkv-kotlin-macosx64:1.2.18")
     
     // Apple Silicon
-    implementation("com.ctrip.flight.mmkv:mmkv-kotlin-macosarm64:1.2.17")
+    implementation("com.ctrip.flight.mmkv:mmkv-kotlin-macosarm64:1.2.18")
 }
 ```
 注意，如果你的工程为 macOS 的 Kotlin/Native 可执行程序工程，或者它直接向一个 iOS 应用程序工程提供 framework，那么您需要手动在工程中添加对 MMKV 的依赖，并可能需要添加对 MMKV 及 MMKVCore 的 `linkerOpts`：

--- a/README_CN.md
+++ b/README_CN.md
@@ -6,7 +6,7 @@ MMKV-Kotlin 是对 [MMKV](https://github.com/Tencent/MMKV) 到 Kotlin Multiplatf
 
 ### 在 Gradle 中使用 Maven 安装引入
 
-Kotlin Multiplatform Common (kts):
+**Kotlin Multiplatform Common (kts):**
 
 ```kotlin
 dependencies { 
@@ -16,12 +16,12 @@ dependencies {
 
 当前版本依赖于 `Kotlin 2.2.0` 以及 `MMKV 2.2.2`。
 
-支持 iOS/macOS 的 Kotlin Multiplatform:
+**支持 iOS/macOS 的 Kotlin Multiplatform:**
 
 如果你的 Kotlin Multiplatform 支持 iOS 或者 macOS，并且它会被构建为一个 Apple framework 供一个 Xcode 工程消费。那么你需要在你的 Xcode
 工程中安装 [MMKV](https://github.com/Tencent/MMKV)，请参考[这里](https://github.com/Tencent/MMKV/wiki/iOS_setup_cn)。
 
-纯 Android 平台（kts）：
+**纯 Android 平台（kts）：**
 
 ```kotlin
 dependencies { 
@@ -29,7 +29,7 @@ dependencies {
 }
 ```
 
-Kotlin/Native on macOS：
+**Kotlin/Native on macOS：**
 
 ```kotlin
 dependencies { 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 
-kotlin = "2.1.20"
-agp = "8.9.2"
-mmkv = "2.1.0"
+kotlin = "2.2.0"
+agp = "8.10.1"
+mmkv = "2.2.2"
 junit = "4.13.2"
 androidx-test = "1.6.1"
 androidx-test-runner = "1.6.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Feb 22 11:03:04 CST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/mmkv-kotlin/MMKV_Kotlin.podspec
+++ b/mmkv-kotlin/MMKV_Kotlin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'mmkv_kotlin'
-    spec.version                  = '1.2.16'
+    spec.version                  = '1.2.18'
     spec.homepage                 = 'Link to the Shared Module homepage'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''
@@ -8,9 +8,8 @@ Pod::Spec.new do |spec|
     spec.summary                  = 'Some description for the Shared Module'
     spec.vendored_frameworks      = 'build/cocoapods/framework/MMKV_Kotlin.framework'
     spec.libraries                = 'c++'
-    spec.ios.deployment_target    = '18.4'
-    spec.osx.deployment_target    = '15.4'
-    spec.dependency 'MMKV', '2.1.0'
+                
+    spec.dependency 'MMKV', '2.2.2'
                 
     if !Dir.exist?('build/cocoapods/framework/MMKV_Kotlin.framework') || Dir.empty?('build/cocoapods/framework/MMKV_Kotlin.framework')
         raise "

--- a/mmkv-kotlin/build.gradle.kts
+++ b/mmkv-kotlin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     signing
 }
 
-version = "1.2.17"
+version = "1.2.18"
 group = "com.ctrip.flight.mmkv"
 
 @OptIn(ExperimentalKotlinGradlePluginApi::class)
@@ -32,8 +32,6 @@ kotlin {
     cocoapods {
         summary = "Some description for the Shared Module"
         homepage = "Link to the Shared Module homepage"
-        ios.deploymentTarget = "18.4"
-        osx.deploymentTarget = "15.4"
         framework {
             baseName = "MMKV-Kotlin"
             isStatic = true

--- a/mmkv-kotlin/build.gradle.kts
+++ b/mmkv-kotlin/build.gradle.kts
@@ -32,6 +32,8 @@ kotlin {
     cocoapods {
         summary = "Some description for the Shared Module"
         homepage = "Link to the Shared Module homepage"
+        ios.deploymentTarget = "13.0"
+        osx.deploymentTarget = "10.15"
         framework {
             baseName = "MMKV-Kotlin"
             isStatic = true

--- a/mmkv-kotlin/src/appleMain/kotlin/com/ctrip/flight/mmkv/Binary.kt
+++ b/mmkv-kotlin/src/appleMain/kotlin/com/ctrip/flight/mmkv/Binary.kt
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+@file:OptIn(ExperimentalForeignApi::class)
+
 package com.ctrip.flight.mmkv
 
 import kotlinx.cinterop.*
@@ -25,7 +28,6 @@ import platform.posix.memcpy
  * @author yaqiao
  */
 
-@OptIn(ExperimentalForeignApi::class)
 internal fun NSData.toByteArray(): ByteArray {
     val size = length.toInt()
     return ByteArray(size).apply {
@@ -35,7 +37,7 @@ internal fun NSData.toByteArray(): ByteArray {
     }
 }
 
-@OptIn(BetaInteropApi::class, ExperimentalForeignApi::class)
+@OptIn(BetaInteropApi::class)
 internal fun ByteArray.toNSData(): NSData = memScoped {
     NSData.create(bytes = allocArrayOf(this@toNSData),
         length = this@toNSData.size.toULong())

--- a/mmkv-kotlin/src/appleMain/kotlin/com/ctrip/flight/mmkv/ExtensionIos.kt
+++ b/mmkv-kotlin/src/appleMain/kotlin/com/ctrip/flight/mmkv/ExtensionIos.kt
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+@file:OptIn(ExperimentalForeignApi::class)
+
 package com.ctrip.flight.mmkv
 
 import kotlinx.cinterop.BetaInteropApi
@@ -26,14 +29,11 @@ import platform.darwin.NSObject
  * @author yaqiao
  */
 
-@OptIn(ExperimentalForeignApi::class)
 operator fun MMKVImpl.set(key: String, value: NSDate) = platformMMKV.setDate(value, key)
 
-@OptIn(ExperimentalForeignApi::class)
 operator fun MMKVImpl.set(key: String, value: NSObject?) = platformMMKV.setObject(value, key)
 
-@OptIn(ExperimentalForeignApi::class)
 fun MMKVImpl.takeNSDate(key: String, default: NSDate? = null): NSDate? = platformMMKV.getDateForKey(key, default)
 
-@OptIn(BetaInteropApi::class, ExperimentalForeignApi::class)
+@OptIn(BetaInteropApi::class)
 fun MMKVImpl.takeObject(key: String, cls: ObjCClass): Any? = platformMMKV.getObjectOfClass(cls, key)

--- a/mmkv-kotlin/src/appleMain/kotlin/com/ctrip/flight/mmkv/InitializeIos.kt
+++ b/mmkv-kotlin/src/appleMain/kotlin/com/ctrip/flight/mmkv/InitializeIos.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalForeignApi::class)
+
 package com.ctrip.flight.mmkv
 
 import cocoapods.MMKV.MMKV
@@ -24,14 +26,8 @@ import kotlinx.cinterop.ExperimentalForeignApi
  * @author yaqiao
  */
 
-@OptIn(ExperimentalForeignApi::class)
-fun initialize() = MMKV.initialize()
+fun initialize(rootDir: String? = null): String = MMKV.initializeMMKV(rootDir)
 
-@OptIn(ExperimentalForeignApi::class)
-fun initialize(rootDir: String): String = MMKV.initializeMMKV(rootDir)
+fun initialize(rootDir: String? = null, logLevel: MMKVLogLevel): String = MMKV.initializeMMKV(rootDir, logLevel.rawValue)
 
-@OptIn(ExperimentalForeignApi::class)
-fun initialize(rootDir: String, logLevel: MMKVLogLevel): String = MMKV.initializeMMKV(rootDir, logLevel.rawValue)
-
-@OptIn(ExperimentalForeignApi::class)
-fun initialize(rootDir: String, groupDir: String, logLevel: MMKVLogLevel): String = MMKV.initializeMMKV(rootDir, groupDir, logLevel.rawValue)
+fun initialize(rootDir: String? = null, groupDir: String, logLevel: MMKVLogLevel): String = MMKV.initializeMMKV(rootDir, groupDir, logLevel.rawValue)

--- a/mmkv-kotlin/src/appleMain/kotlin/com/ctrip/flight/mmkv/UtilIos.kt
+++ b/mmkv-kotlin/src/appleMain/kotlin/com/ctrip/flight/mmkv/UtilIos.kt
@@ -14,29 +14,26 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalForeignApi::class)
+
 package com.ctrip.flight.mmkv
 
 import cocoapods.MMKV.MMKV
 import kotlinx.cinterop.ExperimentalForeignApi
 
 /**
- * Other top-level function
+ * Other top-level functions
  * @author yaqiao
  */
 
-@OptIn(ExperimentalForeignApi::class)
 actual fun backupOneToDirectory(
     mmapID: String, dstDir: String, rootPath: String?
 ): Boolean = MMKV.backupOneMMKV(mmapID, rootPath, dstDir)
 
-@OptIn(ExperimentalForeignApi::class)
 actual fun pageSize(): Long = MMKV.pageSize().toLong()
 
-@OptIn(ExperimentalForeignApi::class)
 actual fun setLogLevel(logLevel: MMKVLogLevel) = MMKV.setLogLevel(logLevel.rawValue)
 
-@OptIn(ExperimentalForeignApi::class)
 actual fun version(): String = MMKV.version()
 
-@OptIn(ExperimentalForeignApi::class)
 actual fun unregisterHandler() = MMKV.unregiserHandler()


### PR DESCRIPTION
* Based on `Kotlin 2.2.0`, `MMKV 2.2.2`
* Fixed a bug of function `initilize()`
* All overload versions of function `initialize` could pass `null` as their parameter `rootDir`
* Fixed README
* Updated GitHub Actions pipeline